### PR TITLE
Set minimum dappnode version

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -28,6 +28,6 @@
   },
   "license": "GLP-3.0",
   "requirements": {
-    "minimumDappnodeVersion": "0.2.51"
+    "minimumDappnodeVersion": "0.2.56"
   }
 }


### PR DESCRIPTION
Set the requirement to have the core release 0.2.56 to install web3signer gnosis