### PR TITLE
Import one by one each keystore during manual migration

### DIFF
--- a/web3signer/Dockerfile
+++ b/web3signer/Dockerfile
@@ -6,6 +6,8 @@ ARG UPSTREAM_VERSION
 # golang alpine 1.17
 FROM golang:1.17-alpine as importer
 WORKDIR /usr/src/app
+# Needed to create binary to be executed in debian. See https://pkg.go.dev/cmd/cgo
+ENV CGO_ENABLED=0
 RUN apk update && apk add git && git clone https://github.com/dappnode/web3signer-import-one-by-one.git && \
   go build -o import-one-by-one ./web3signer-import-one-by-one/import_one_by_one.go
 

--- a/web3signer/Dockerfile
+++ b/web3signer/Dockerfile
@@ -1,5 +1,18 @@
 ARG UPSTREAM_VERSION
 
+###############
+# Prune image #
+###############
+# golang alpine 1.17
+FROM golang:1.17-alpine as import-one-by-one
+WORKDIR /usr/src/app
+RUN apk update && apk add git && git clone https://github.com/dappnode/web3signer-import-one-by-one.git && \
+  go build -o import-one-by-one ./web3signer-import-one-by-one/import-one-by-one.go
+
+################
+# Runner image #
+################
+
 FROM consensys/web3signer:$UPSTREAM_VERSION
 USER root
 RUN apt update && apt install cron inotify-tools jq ca-certificates unzip --yes
@@ -10,6 +23,9 @@ COPY delete-keys.sh /usr/bin/delete-keys.sh
 COPY reload-keys.sh /usr/bin/reload-keys.sh
 COPY reload-keys-cron /etc/cron.d/
 COPY entrypoint.sh /usr/bin/entrypoint.sh
+
+# Copy import one-by-one
+COPY --from=import-one-by-one /usr/src/app/import-one-by-one /usr/local/bin
 
 # Apply cron job
 RUN crontab /etc/cron.d/reload-keys-cron

--- a/web3signer/Dockerfile
+++ b/web3signer/Dockerfile
@@ -7,7 +7,7 @@ ARG UPSTREAM_VERSION
 FROM golang:1.17-alpine as importer
 WORKDIR /usr/src/app
 RUN apk update && apk add git && git clone https://github.com/dappnode/web3signer-import-one-by-one.git && \
-  go build -o import-one-by-one ./web3signer-import-one-by-one/import-one-by-one.go
+  go build -o import-one-by-one ./web3signer-import-one-by-one/import_one_by_one.go
 
 ################
 # Runner image #

--- a/web3signer/Dockerfile
+++ b/web3signer/Dockerfile
@@ -4,7 +4,7 @@ ARG UPSTREAM_VERSION
 # Prune image #
 ###############
 # golang alpine 1.17
-FROM golang:1.17-alpine as import-one-by-one
+FROM golang:1.17-alpine as importer
 WORKDIR /usr/src/app
 RUN apk update && apk add git && git clone https://github.com/dappnode/web3signer-import-one-by-one.git && \
   go build -o import-one-by-one ./web3signer-import-one-by-one/import-one-by-one.go
@@ -25,7 +25,7 @@ COPY reload-keys-cron /etc/cron.d/
 COPY entrypoint.sh /usr/bin/entrypoint.sh
 
 # Copy import one-by-one
-COPY --from=import-one-by-one /usr/src/app/import-one-by-one /usr/local/bin
+COPY --from=importer /usr/src/app/import-one-by-one /usr/local/bin
 
 # Apply cron job
 RUN crontab /etc/cron.d/reload-keys-cron

--- a/web3signer/Dockerfile
+++ b/web3signer/Dockerfile
@@ -25,7 +25,7 @@ COPY reload-keys-cron /etc/cron.d/
 COPY entrypoint.sh /usr/bin/entrypoint.sh
 
 # Copy import one-by-one
-COPY --from=importer /usr/src/app/import-one-by-one /usr/local/bin
+COPY --from=importer /usr/src/app/import-one-by-one /usr/bin
 
 # Apply cron job
 RUN crontab /etc/cron.d/reload-keys-cron

--- a/web3signer/entrypoint.sh
+++ b/web3signer/entrypoint.sh
@@ -79,7 +79,7 @@ exec /opt/web3signer/bin/web3signer \
   --metrics-host 0.0.0.0 \
   --metrics-port 9091 \
   --metrics-host-allowlist="*" \
-  --idle-connection-timeout-seconds=90 \
+  --idle-connection-timeout-seconds=360 \
   eth2 \
   --network=gnosis \
   --slashing-protection-db-url=jdbc:postgresql://postgres.web3signer-gnosis.dappnode:5432/web3signer-gnosis \

--- a/web3signer/entrypoint.sh
+++ b/web3signer/entrypoint.sh
@@ -79,6 +79,7 @@ exec /opt/web3signer/bin/web3signer \
   --metrics-host 0.0.0.0 \
   --metrics-port 9091 \
   --metrics-host-allowlist="*" \
+  --idle-connection-timeout-seconds=90 \
   eth2 \
   --network=gnosis \
   --slashing-protection-db-url=jdbc:postgresql://postgres.web3signer-gnosis.dappnode:5432/web3signer-gnosis \


### PR DESCRIPTION
Due to the time it takes to decrypt the keystore with the walletpassword, it is a safer approach to import the keystores one by one to avoid timeout errors and overload  the web3signer.

- Import one by one each keystore
- Increase the IDLE connection timeout to 360 s 