### PR TITLE
Schedule gnosis shapella

### DIFF
--- a/web3signer/entrypoint.sh
+++ b/web3signer/entrypoint.sh
@@ -63,6 +63,7 @@ exec /opt/web3signer/bin/web3signer \
   --idle-connection-timeout-seconds=900 \
   eth2 \
   --network=gnosis \
+  --Xnetwork-capella-fork-epoch=648704 \
   --slashing-protection-db-url=jdbc:postgresql://postgres.web3signer-gnosis.dappnode:5432/web3signer-gnosis \
   --slashing-protection-db-username=postgres \
   --slashing-protection-db-password=gnosis \


### PR DESCRIPTION
Web3signer version 23.6.0 does NOT have Gnosis shapella scheduled. Upstream version is https://github.com/dappnode/DAppNodePackage-web3signer-gnosis/blob/ccf1ff3e1a16a733b1cf141ac5d1c1987acfba26/dappnode_package.json#L4

Teku scheduled capella on version 23.6.1 https://github.com/Consensys/teku/commit/27981e662ec6e7e3415cbf905941156956cea16f but web3signer still depends on 23.6.0 https://github.com/Consensys/web3signer/blob/1f4a58ff52c55574e681a801058f185dddbf39cf/gradle/versions.gradle#L93

Since the hard fork is in less than 24h, this fix allows the dappnode package to have the correct scheduling without waiting for an upstream release.

Correct epoch pulled from https://github.com/gnosischain/configs/blob/b90374a1c63703db8235fcdb65aff2e909bc42b5/mainnet/config.yaml#L153C21-L153C27