### PR TITLE
Bump brain to 0.1.17

### DIFF
--- a/brain/Dockerfile
+++ b/brain/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/dappnode/staking-brain:0.1.16
+FROM ghcr.io/dappnode/staking-brain:0.1.17
 ENV NETWORK=gnosis

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -28,10 +28,7 @@
   },
   "license": "Apache-2.0",
   "requirements": {
-    "minimumDappnodeVersion": "0.2.89"
-  },
-  "optionalDependencies": {
-    "prysm-prater.dnp.dappnode.eth": "1.0.28"
+    "minimumDappnodeVersion": "0.2.69"
   },
   "warnings": {
     "onMajorUpdate": "This update will do a migration, it is recommended to have a backup of your keystores (http://my.dappnode/#/packages/web3signer-gnosis.dnp.dappnode.eth/backup)."

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -28,7 +28,10 @@
   },
   "license": "Apache-2.0",
   "requirements": {
-    "minimumDappnodeVersion": "0.2.69"
+    "minimumDappnodeVersion": "0.2.89"
+  },
+  "optionalDependencies": {
+    "prysm-prater.dnp.dappnode.eth": "1.0.28"
   },
   "warnings": {
     "onMajorUpdate": "This update will do a migration, it is recommended to have a backup of your keystores (http://my.dappnode/#/packages/web3signer-gnosis.dnp.dappnode.eth/backup)."


### PR DESCRIPTION
Bump brain to `v0.1.17` to match new auth-token for Prysm validator (Prysm has been deprecated in gnosis)