### PR TITLE
Bump brain to 0.1.19

### DIFF
--- a/brain/Dockerfile
+++ b/brain/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/dappnode/staking-brain:0.1.17
+FROM ghcr.io/dappnode/staking-brain:0.1.19
 ENV NETWORK=gnosis


### PR DESCRIPTION
Bump brain to 0.1.19 to allow Stakewise operator to upload keystores to the signer