### PR TITLE
Add signer url set by brain when relading validators

### DIFF
--- a/web3signer/entrypoint.sh
+++ b/web3signer/entrypoint.sh
@@ -41,8 +41,8 @@ exec /opt/web3signer/bin/web3signer \
   --key-store-path="$KEYFILES_DIR" \
   --http-listen-port=9000 \
   --http-listen-host=0.0.0.0 \
-  --http-host-allowlist="web3signer.web3signer-gnosis.dappnode,brain.web3signer-gnosis.dappnode,$ETH2_CLIENT_DNS" \
-  --http-cors-origins="http://web3signer.web3signer-gnosis.dappnode,http://brain.web3signer-gnosis.dappnode,http://$ETH2_CLIENT_DNS" \
+  --http-host-allowlist="signer.gnosis.dncore.dappnode,web3signer.web3signer-gnosis.dappnode,brain.web3signer-gnosis.dappnode,$ETH2_CLIENT_DNS" \
+  --http-cors-origins="http://signer.gnosis.dncore.dappnode,http://web3signer.web3signer-gnosis.dappnode,http://brain.web3signer-gnosis.dappnode,http://$ETH2_CLIENT_DNS" \
   --metrics-enabled=true \
   --metrics-host 0.0.0.0 \
   --metrics-port 9091 \


### PR DESCRIPTION
The brain is posting validators pubkeys with signer url `signer.<network>.dncore.dappnode` which is the alias set by default by the brain. This alias must be whitelisted